### PR TITLE
Fix/db2 down behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,5 @@ It means the exporter is unable to connect to DB2, however it doesn't know why. 
 
 - Verify that the DSN being used by the exporter is correct for the instance/database of DB2 being monitored.
 - Verify that DB2 is running and all of it's communication protocols are activated.
+
+After making any necessary changes restart the exporter.

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ IBM_DB2_EXPORTER_DB="database"
 ```
 
 # Troubleshooting
-Due to the driver used by this exporter, watch out for the following error message:
+
+If you get this error message:
 
 `ping is failing: verify DSN is correct and DB2 is running properly`
 
-When this error appears, it means the exporter is unable to connect to DB2, however it doesn't know why. To fix this error, try one of the following solutions.
+It means the exporter is unable to connect to DB2, however it doesn't know why. To fix this error, please ensure the following:
 
 - Verify that the DSN being used by the exporter is correct for the instance/database of DB2 being monitored.
-- Verify that DB2 is running and all of it's communication protocols are activated. 
-
+- Verify that DB2 is running and all of it's communication protocols are activated.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ db2
 activate database sample
 quit
 ```
-To deactivate a database, connect to db2 and run the command `deactivate database <dbname>` and disconnect. Doing so will reset the metrics reported by DB2. The database must be reactivated in order for metrics to be properly incremented, stored, and reported by DB2.
+To deactivate a database, connect to DB2 and run the command `deactivate database <dbname>` and disconnect. Doing so will reset the metrics reported by DB2. The database must be reactivated in order for metrics to be properly incremented, stored, and reported by DB2. This also applies to whenever DB2 is shutdown.
+
 **Note:** Whether or not the database is activated only affects DB2's ability to report metrics, it does not affect DB2's behavior as a database.
 
 ## Driver installation (optional)
@@ -83,3 +84,14 @@ IBM_DB2_EXPORTER_DB="database"
 
 ./ibm_db2_exporter
 ```
+
+# Troubleshooting
+Due to the driver used by this exporter, watch out for the following error message:
+
+`ping is failing: verify DSN is correct and DB2 is running properly`
+
+When this error appears, it means the exporter is unable to connect to DB2, however it doesn't know why. To fix this error, try one of the following solutions.
+
+- Verify that the DSN being used by the exporter is correct for the instance/database of DB2 being monitored.
+- Verify that DB2 is running and all of it's communication protocols are activated. 
+

--- a/README.md
+++ b/README.md
@@ -97,3 +97,9 @@ It means the exporter is unable to connect to DB2, however it doesn't know why. 
 - Verify that DB2 is running and all of it's communication protocols are activated.
 
 After making any necessary changes restart the exporter.
+
+**Tip:** To verify whether or not the port being used by DB2 is cleared and ready for restart, try the following command.
+```
+netstat -ane | grep "<db2-port>"
+```
+This command will output the state of the port replacing `<db2-port>`. This port is whatever is used in the DSN. The default port that DB2 uses is `50000`.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -227,8 +227,11 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 func (c *Collector) ensureConnection() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// mainly here so unit tests work
+
 	if c.db != nil {
+		// this check is done so unit tests can work
+		// placed after mutex so threads do not jump over this func
+		// can occur when live if Ping takes too long to return
 		return nil
 	}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -227,15 +227,14 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 func (c *Collector) ensureConnection() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// mainly here so unit tests work
+	if c.db != nil {
+		return nil
+	}
 
 	if c.pingFail {
 		// ping has failed, continually return err
 		return fmt.Errorf("ping is failing: verify DSN is correct and DB2 is running properly")
-	}
-
-	// mainly here so unit tests work
-	if c.db != nil {
-		return nil
 	}
 
 	db, err := sql.Open("go_ibm_db", c.config.DSN)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -75,7 +75,7 @@ func TestCollector_Collect(t *testing.T) {
 	t.Run("Database connection fails", func(t *testing.T) {
 		col := NewCollector(log.NewJSONLogger(os.Stdout), &Config{})
 
-		openErr := col.openDB()
+		openErr := col.ensureConnection()
 		require.Error(t, openErr)
 
 		f, err := os.Open(filepath.Join("testdata", "query_failure.prom"))

--- a/collector/testdata/all_metrics.prom
+++ b/collector/testdata/all_metrics.prom
@@ -34,7 +34,7 @@ ibm_db2_log_operations_total{database_name="",log_member="2",log_operation_type=
 ibm_db2_log_operations_total{database_name="",log_member="2",log_operation_type="write"} 9
 ibm_db2_log_operations_total{database_name="",log_member="3",log_operation_type="read"} 3
 ibm_db2_log_operations_total{database_name="",log_member="3",log_operation_type="write"} 4
-# HELP ibm_db2_log_usage The disk blocks of active logs pace in the database that is not being used by uncommitted transactions. Each block correlates to 4 KiB blocks of storage.
+# HELP ibm_db2_log_usage The disk blocks of active logs space in the database that is not being used by uncommitted transactions. Each block correlates to 4 KiB blocks of storage.
 # TYPE ibm_db2_log_usage gauge
 ibm_db2_log_usage{database_name="",log_member="1",log_usage_type="available"} 22
 ibm_db2_log_usage{database_name="",log_member="1",log_usage_type="used"} 33
@@ -59,6 +59,6 @@ ibm_db2_tablespace_usage{database_name="",tablespace_name="tbsp2",tablespace_typ
 ibm_db2_tablespace_usage{database_name="",tablespace_name="tbsp3",tablespace_type="free"} 111
 ibm_db2_tablespace_usage{database_name="",tablespace_name="tbsp3",tablespace_type="total"} 999
 ibm_db2_tablespace_usage{database_name="",tablespace_name="tbsp3",tablespace_type="used"} 222
-# HELP ibm_db2_up Metric indicating the status of the exporter collection. 1 indicates that the connection to IBM DB2 was successful, and all available metrics were collected. A 0 indicates that the exporter failed to collect 1 or more metrics, due to an inability to connect to IBM DB2.
+# HELP ibm_db2_up Metric indicating the status of the exporter collection. 1 indicates that the connection to IBM DB2 was successful, and all available metrics were collected. A 0 indicates that the exporter failed to collect metrics or to connect to IBM DB2.
 # TYPE ibm_db2_up gauge
 ibm_db2_up{database_name=""} 1

--- a/collector/testdata/query_failure.prom
+++ b/collector/testdata/query_failure.prom
@@ -1,3 +1,3 @@
-# HELP ibm_db2_up Metric indicating the status of the exporter collection. 1 indicates that the connection to IBM DB2 was successful, and all available metrics were collected. A 0 indicates that the exporter failed to collect 1 or more metrics, due to an inability to connect to IBM DB2.
+# HELP ibm_db2_up Metric indicating the status of the exporter collection. 1 indicates that the connection to IBM DB2 was successful, and all available metrics were collected. A 0 indicates that the exporter failed to collect metrics or to connect to IBM DB2.
 # TYPE ibm_db2_up gauge
 ibm_db2_up{database_name=""} 0


### PR DESCRIPTION
While testing the integration for DB2, a bug was found in the exporter whenever DB2 was turned off due to the following factors:

1. The driver used to connect to DB2 lacks implementation of the SQL library Ping interface.
2. Since Ping is not implemented, the default implementation is utilized whenever Ping is called which does not allow the use of a cancel ctx to cancel the Ping calls.
3. The default implementation attempts to establish a connection with DB2.
4. As DB2 is turned off, the TCP communication over the designated port fails, triggering a protocol to verify the shutdown.
DB2, being turned off, cannot participate in the shutdown protocol, resulting in the protocol getting stuck, waiting for an acknowledgment message.
5. Consequently, all other requests that use the same port start queuing up, waiting for access.
6. The port remains occupied until the operating system's TCP connection timeout is reached, which can take a minute or longer.
7. The Prometheus server, which employs multiple threads to Ping DB2, becomes unresponsive and hangs in this situation.

In summary, when DB2 is turned off, the unavailability of the database leads to a protocol hang, causing requests to queue up and preventing the port from clearing until the OS timeout expires. This, in turn, causes the Prometheus server to hang while attempting to Ping DB2.

This fix changes the behavior of the exporter so that it does not hang when DB2 is turned off/shutdowns. Instead, it transitions to a state where it continually reports DB2 is down with the "ibm_db2_up" metric. The exporter will not reach back out to DB2 until it is restarted to remove it from the state. 

This "solution" is used for a couple of reasons.
1. The sql/driver function that errors out and causes this bug(Ping) also catches when a DSN string is incorrect. In that situation the exporter needs to be restarted, and the exporter is unable to tell the difference between these 2 errors returned by Ping.
2. In order for DB2 to be properly restarted, the port being used to connect to DB2 needs to be clear. This means the tcp protocol that hangs because DB2 cannot partake puts the port into a busy state, thus preventing DB2 from properly restarting. The exporter could just wait x amount of minutes between calls to DB2 after the first failure, but it would fall on the user to get DB2 properly restarted within some time window. 

Whenever DB2 is off/unable to be connected to, the exporter will report an error message hinting that the DSN may be incorrect and/or DB2 needs to be restarted. This PR adds documentation to the README.md that informs the user of how to troubleshoot this error.