### PR TITLE
Add documentation for Windows set-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # **ibm-db2-prometheus-exporter**
+
 Exports [IBM DB2](https://www.ibm.com/products/db2/database) metrics via HTTP for Prometheus consumption.
 
 **Note:** This exporter is not compatible with ARM64 architectures due to restrictions with the driver.
@@ -7,12 +8,14 @@ Exports [IBM DB2](https://www.ibm.com/products/db2/database) metrics via HTTP fo
 
 The [go_ibm_db driver](https://github.com/ibmdb/go_ibm_db) needs installed C library files in order to connect to the database. A minimal setup could be provided via using the [clidriver](https://github.com/ibmdb/go_ibm_db/blob/master/installer/setup.go).
 
-In order for DB2 to correctly report metric values, the database being monitored must be "explicitly activated". Doing so will make it so that certain metric values are correctly incremented and not periodically reset. However, it does result in a performance impact on the environment DB2 is running in. The size of this impact will depend on the system, but will result in the most accurate data reported by DB2 and, subsequently, this exporter. To explicitly activate a database, connect to DB2 and run the command `activate database <dbname>` and disconnect. Now DB2 will correctly increment and store metrics. 
+In order for DB2 to correctly report metric values, the database being monitored must be "explicitly activated". Doing so will make it so that certain metric values are correctly incremented and not periodically reset. However, it does result in a performance impact on the environment DB2 is running in. The size of this impact will depend on the system, but will result in the most accurate data reported by DB2 and, subsequently, this exporter. To explicitly activate a database, connect to DB2 and run the command `activate database <dbname>` and disconnect. Now DB2 will correctly increment and store metrics.
+
 ```
 db2
 activate database sample
 quit
 ```
+
 To deactivate a database, connect to DB2 and run the command `deactivate database <dbname>` and disconnect. Doing so will reset the metrics reported by DB2. The database must be reactivated in order for metrics to be properly incremented, stored, and reported by DB2. This also applies to whenever DB2 is shutdown.
 
 **Note:** Whether or not the database is activated only affects DB2's ability to report metrics, it does not affect DB2's behavior as a database.
@@ -24,10 +27,10 @@ go install github.com/ibmdb/go_ibm_db/installer@latest
 ```
 
 Make sure to have the clidriver set up:
+
 ```
 cd go/pkg/mod/github.com/ibmdb/go_ibm_db\@latest/installer && go run setup.go
 ```
-
 
 ## Required environment variables
 
@@ -44,9 +47,11 @@ CGO_CFLAGS=-I/usr/local/go/pkg/mod/github.com/ibmdb/clidriver/include
 You can build a binary of the exporter by running `make exporter` in this directory.
 
 **Note:** This exporter only connects to a single database. To monitor multiple databases, each one will need an exporter.
+
 ## Command line flags
 
 The exporter may be configured through its command line flags (run with -h to see options):
+
 ```
   -h, --[no-]help                Show context-sensitive help (also try --help-long and --help-man).
       --[no-]web.systemd-socket  Use systemd socket activation listeners instead of port listeners (Linux only).
@@ -68,19 +73,23 @@ The exporter may be configured through its command line flags (run with -h to se
 ```
 
 Example usage:
+
 ```
 ./ibm_db2_exporter --db="database" --dsn="DATABASE=database;HOSTNAME=localhost;PORT=50000;UID=user;PWD=password;"
 ```
+
 **Note:**
-  - `--dsn` and `--db` are required flags, if not set as environment variables.
-  - This exporter does not verify DSN strings. If you have trouble connecting, make sure the DSN is configured correctly.
+
+- `--dsn` and `--db` are required flags, if not set as environment variables.
+- This exporter does not verify DSN strings. If you have trouble connecting, make sure the DSN is configured correctly.
 
 ## Environment Variables:
 
-You can also set the DSN and DB as environment variables and then run the exporter:  
+You can also set the DSN and DB as environment variables and then run the exporter:
+
 ```
-IBM_DB2_EXPORTER_DSN="DATABASE=database;HOSTNAME=localhost;PORT=50000;UID=user;PWD=password;"  
-IBM_DB2_EXPORTER_DB="database"  
+IBM_DB2_EXPORTER_DSN="DATABASE=database;HOSTNAME=localhost;PORT=50000;UID=user;PWD=password;"
+IBM_DB2_EXPORTER_DB="database"
 
 ./ibm_db2_exporter
 ```
@@ -94,12 +103,14 @@ If you get this error message:
 It means the exporter is unable to connect to DB2, however it doesn't know why. To fix this error, please ensure the following:
 
 - Verify that the DSN being used by the exporter is correct for the instance/database of DB2 being monitored.
-- Verify that DB2 is running and all of it's communication protocols are activated.
+- Verify that DB2 is running and all of its communication protocols are activated.
 
 After making any necessary changes restart the exporter.
 
 **Tip:** To verify whether or not the port being used by DB2 is cleared and ready for restart, try the following command.
+
 ```
 netstat -ane | grep "<db2-port>"
 ```
+
 This command will output the state of the port replacing `<db2-port>`. This port is whatever is used in the DSN. The default port that DB2 uses is `50000`.

--- a/windows_setup.md
+++ b/windows_setup.md
@@ -1,0 +1,92 @@
+# **ibm-db2-prometheus-exporter on Windows**
+
+Although this exporter was originally designed to support Linux, it can work on Windows. The steps in this document will outline various differences in the setup process for Windows systems.
+
+**Note**: This document was tested against Windows Server 2022 using PowerShell.
+
+## Prerequisites
+
+The following technologies must be present:
+
+- Git (2.43.0.windows.1)
+- Go (1.21.6)
+- IBM DB2 (11.5.9)
+
+_The versions listed above were used to test the exporter, but may not represent a necessary version. If difficulties arise, consider upgrading to similar versions._
+
+The final outside technology that must be installed is `Chocolatey`. This will provide the Windows equivalent of `make` so that the exporter binary can be built. Run these 2 commands to install `Chocolatey` and `make` respectively:
+
+```bash
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+chaco install make
+```
+
+### ENV Variables
+
+Like in the Linux instructions, the exporter requires that certain environment variables be set:
+
+```bash
+set-item -path env:LD_LIBRARY_PATH -value "go\pkg\mod\github.com\ibmdb\clidriver\lib"
+set-item -path env:CGO_LDFLAGS -value "-L\<Path to go>\go\pkg\mod\github.com\ibmdb\tmp\clidriver\lib"
+set-item -path env:CGO_CFLAGS -value "-I\<Path to go>\go\pkg\mod\github.com\ibmdb\clidriver\include"
+set-item -path env:Db2CLP -value "**$**"
+```
+
+_Be sure to replace the `<Path to go>` with the path to the `go` directory. This will usually be under the user that Go was installed on._
+
+### DB2 Setup
+
+This guide assumes IBM DB2 is installed and running. If it has not been done already, [initialize the DB2 CLI environment](https://www.ibm.com/support/pages/db21061e-environment-not-initialized-when-running-db2-commands-windows-command-line) explicitly activate the database, and [connect to it](https://www.xtivia.com/blog/how-to-connect-to-a-db2-database/):
+
+```bash
+db2cmd -i -w db2clpsetcp
+db2 activate database <database>
+db2 connect to <database>
+```
+
+**Note:** Database activation only affects DB2's ability to report metrics, it does not affect DB2's behavior as a database.
+
+The final requirement for DB2 is to have a user with correct permissions. To give a user `DATAACCESS` permissions, execute the following command:
+
+```bash
+db2 grant dataaccess on database to user <username>
+```
+
+_Be sure to replace the `<username>` with the name of the user._
+
+## Install DB2 Driver
+
+Similarly to Linux, the [go_ibm_driver](https://github.com/ibmdb/go_ibm_db) should be installed and set-up:
+
+```bash
+go install github.com/ibmdb/go_ibm_db/installer@latest
+cd go\pkg\mod\github.com\ibmdb\go_ibm_db@<version>\installer
+go run setup.go
+```
+
+_Be sure to replace the `<version>` with the version that was installed._
+
+## Exporter
+
+After cloning the exporter, modify the `go build` command in the `Makefile` so that the outputted binary is an executable:
+
+```bash
+go build -o ./bin/ibm_db2_exporter.exe ./cmd/ibm-db2-exporter/main.go
+```
+
+Build the binary and run the exporter, passing in the credentials of a user with permissions enabled:
+
+```bash
+make exporter
+.\bin\ibm_db2_exporter.exe --db="database" --dsn="DATABASE=database;HOSTNAME=localhost;PORT=50000;UID=username;PWD=password
+```
+
+_Be sure to replace each field with information specific to the database and user._
+
+At this point, metrics should be appearing upon running the following command:
+
+```bash
+curl <hostname>:9953/metrics
+```
+
+If there are no errors in the output of the exporter, the exporter is configured and running correctly. If errors occur, consult the `Troubleshooting` section of the main README file.


### PR DESCRIPTION
**Purpose**

This PR adds documentation for how to configure and run this exporter on Windows rather than Linux (which is the only officially supported platform).