### PR TITLE
feat: update IBM DB2 log expression to use log_type label

### DIFF
--- a/mixin/dashboards/ibm-db2-overview.libsonnet
+++ b/mixin/dashboards/ibm-db2-overview.libsonnet
@@ -634,7 +634,7 @@ local diagnosticLogsPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/home/.*/sqllib/db2dump/DIAG.*/db2diag.log|/home/.*/sqllib/db2dump/db2diag.log"} |= ``',
+      expr: '{' + matcher + '} |= `` | (filename=~"/home/.*/sqllib/db2dump/DIAG.*/db2diag.log|/home/.*/sqllib/db2dump/db2diag.log" or log_type="db2diag")',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
### Description

This PR adds a small update to the mixin for the log expression. It adds the `log_type` label and updates the expression to also use the `matcher` selectors. The intention is to update the `k8s` plugin snippet for logs to use the `log_type` label, avoiding potential confusion with needing to add an arbitrary value to the `filename` label.

> This is untested in `k8s`, so there's no confirmation that the diagnostic logs are sent to the DB2 container's `stdout`.

### Changes
* [update log expression to use filename and log_type labels](https://github.com/grafana/ibm-db2-prometheus-exporter/commit/0144efc1d248f8d08e6c50dc340bf4dc296b8795)