### PR TITLE
expose `customAllValue` to the IBM DB2 mixin

### DIFF
--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -3,6 +3,8 @@
   filteringSelector: '',
   groupLabels: ['job', 'cluster'],
   instanceLabels: ['instance', 'database_name'],
+  customAllValue: '.*', // Override this as desired. '.+' is a good option if you want to ensure a label is present.
+
 
   uid: 'ibm-db2',
   dashboardTags: [self.uid + '-mixin'],

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -3,8 +3,7 @@
   filteringSelector: '',
   groupLabels: ['job', 'cluster'],
   instanceLabels: ['instance', 'database_name'],
-  customAllValue: '.*', // Override this as desired. '.+' is a good option if you want to ensure a label is present.
-
+  customAllValue: '.*',  // Override this as desired. '.+' is a good option if you want to ensure a label is present.
 
   uid: 'ibm-db2',
   dashboardTags: [self.uid + '-mixin'],

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -3,7 +3,7 @@
   filteringSelector: '',
   groupLabels: ['job', 'cluster'],
   instanceLabels: ['instance', 'database_name'],
-  customAllValue: '.*',  // Override this as desired. '.+' is a good option if you want to ensure a label is present.
+  customAllValue: '.*',  // Override this as desired. '.+' is a good option if you want to ensure a label is present
 
   uid: 'ibm-db2',
   dashboardTags: [self.uid + '-mixin'],

--- a/mixin/dashboards.libsonnet
+++ b/mixin/dashboards.libsonnet
@@ -51,6 +51,7 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
           labels=this.config.groupLabels + this.config.extraLogLabels,
           formatParser=null,
           showLogsVolume=this.config.showLogsVolume,
+          customAllValue=this.config.customAllValue,
         )
         {
           dashboards+:

--- a/mixin/dashboards_out/ibm-db2-logs.json
+++ b/mixin/dashboards_out/ibm-db2-logs.json
@@ -248,7 +248,7 @@
                "label": "Cluster",
                "multi": true,
                "name": "cluster",
-               "query": "label_values({,job=~\"$job\"}, cluster)",
+               "query": "label_values({job=~\"$job\"}, cluster)",
                "refresh": 2,
                "sort": 1,
                "type": "query"
@@ -263,7 +263,7 @@
                "label": "Level",
                "multi": true,
                "name": "level",
-               "query": "label_values({,job=~\"$job\",cluster=~\"$cluster\"}, level)",
+               "query": "label_values({job=~\"$job\",cluster=~\"$cluster\"}, level)",
                "refresh": 2,
                "sort": 1,
                "type": "query"
@@ -278,7 +278,7 @@
                "label": "Severity",
                "multi": true,
                "name": "severity",
-               "query": "label_values({,job=~\"$job\",cluster=~\"$cluster\",level=~\"$level\"}, severity)",
+               "query": "label_values({job=~\"$job\",cluster=~\"$cluster\",level=~\"$level\"}, severity)",
                "refresh": 2,
                "sort": 1,
                "type": "query"

--- a/mixin/dashboards_out/ibm-db2-overview.json
+++ b/mixin/dashboards_out/ibm-db2-overview.json
@@ -36,7 +36,7 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "thresholds"
                   },
                   "mappings": [
@@ -55,7 +55,16 @@
                         },
                         "type": "value"
                      }
-                  ]
+                  ],
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  }
                }
             },
             "gridPos": {
@@ -100,12 +109,20 @@
             "description": "The amount of active connections to the database.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "short"
                }
@@ -167,12 +184,20 @@
             "description": "The number of row operations that are being performed on the database.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "short"
                }
@@ -222,12 +247,20 @@
             "description": "The percentage of time that the database manager did not need to load a page from disk to service a page request.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "percent"
                }
@@ -288,12 +321,20 @@
             "description": "The size and usage of table spaces.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "decbytes"
                }
@@ -354,6 +395,10 @@
             "description": "The average wait time for a database while acquiring locks.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -362,6 +407,7 @@
                      "showPoints": "never"
                   },
                   "thresholds": {
+                     "mode": "absolute",
                      "steps": [
                         {
                            "color": "green",
@@ -419,6 +465,10 @@
             "description": "The number of deadlocks occurring on the database.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -427,6 +477,7 @@
                      "showPoints": "never"
                   },
                   "thresholds": {
+                     "mode": "absolute",
                      "steps": [
                         {
                            "color": "green",
@@ -485,12 +536,20 @@
             "description": "The number of locks active and waiting in use in the database.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "short"
                }
@@ -552,8 +611,17 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "thresholds"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
                   },
                   "unit": "percent"
                }
@@ -600,12 +668,20 @@
             "description": "The number of log pages read and written to by the logger.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "short"
                }

--- a/mixin/jsonnetfile.lock.json
+++ b/mixin/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "gen/grafonnet-latest"
         }
       },
-      "version": "8a27651b56fbdba45a389ccb11440200091c73a1",
+      "version": "7380c9c64fb973f34c3ec46265621a2b0dee0058",
       "sum": "V9vAj21qJOc2DlMPDgB1eEjSQU4A+sAA4AXuJ6bd4xc="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "gen/grafonnet-v11.0.0"
         }
       },
-      "version": "42d098fae987f25f08480e203ca6ddc548c6efbf",
+      "version": "7380c9c64fb973f34c3ec46265621a2b0dee0058",
       "sum": "0BvzR0i4bS4hc2O3xDv6i9m52z7mPrjvqxtcPrGhynA="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "gen/grafonnet-v11.4.0"
         }
       },
-      "version": "8a27651b56fbdba45a389ccb11440200091c73a1",
+      "version": "7380c9c64fb973f34c3ec46265621a2b0dee0058",
       "sum": "aVAX09paQYNOoCSKVpuk1exVIyBoMt/C50QJI+Q/3nA="
     },
     {
@@ -48,8 +48,8 @@
           "subdir": "common-lib"
         }
       },
-      "version": "54a1543d797d49814d2f9c05b9c222b9f1e4f6e7",
-      "sum": "XnpzeZC2Pa1aEtDOqy+KTndcUTnwFMlj6XlZmv3XBj0="
+      "version": "229f60f870dd89d8b6e49c76aa70c31f4249f91d",
+      "sum": "PHS3edTM+rA7cKYn8Qovv/0D+i8V5yWMFIkcMtv4WfA="
     },
     {
       "source": {
@@ -58,7 +58,7 @@
           "subdir": "grafana-cloud-integration-utils"
         }
       },
-      "version": "d1eede9462c03d44dcd4a707aa8e7dcaf155a552",
+      "version": "229f60f870dd89d8b6e49c76aa70c31f4249f91d",
       "sum": "f4RYXgxayzDyeBjedbcUWaxIk3WN+y+wsEwcn+cWnJw="
     },
     {
@@ -68,8 +68,8 @@
           "subdir": "logs-lib"
         }
       },
-      "version": "54a1543d797d49814d2f9c05b9c222b9f1e4f6e7",
-      "sum": "0xwYsW92n4rE9PfO3drN4Ko9VeQBoV/IZ7nvgrnYaWk="
+      "version": "229f60f870dd89d8b6e49c76aa70c31f4249f91d",
+      "sum": "rgzaIMC4Gujx86mPdsVfQnzSfxzfuCg/sZPrDJBV3bU="
     },
     {
       "source": {
@@ -88,8 +88,8 @@
           "subdir": ""
         }
       },
-      "version": "4eee017d21cb63a303925d1dcd9fc5c496809b46",
-      "sum": "Kh0GbIycNmJPzk6IOMXn1BbtLNyaiiimclYk7+mvsns="
+      "version": "4d7f8cb24d613430799f9d56809cc6964f35cea9",
+      "sum": "hOrwkOx34tOXqoDVnwuI/Uf/dr9HFFSPWpDPOvnEGrk="
     },
     {
       "source": {


### PR DESCRIPTION
This PR introduces changes to the mixin for IBM DB2 in order to expose the `customAllValue` option in logs-lib, in order to edit it.

