### PR TITLE
fix: Duplicate database_name variable in the mixin

### DIFF
--- a/mixin/dashboards.libsonnet
+++ b/mixin/dashboards.libsonnet
@@ -27,12 +27,7 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
             ])
           )
         ) + root.applyCommon(
-          vars.multiInstance + [
-            g.dashboard.variable.query.new('database_name')
-            + g.dashboard.variable.custom.selectionOptions.withMulti(true)
-            + g.dashboard.variable.query.queryTypes.withLabelValues(label='database_name', metric='ibm_db2_application_active{%(queriesSelector)s}' % vars)
-            + g.dashboard.variable.query.withDatasourceFromVariable(vars.datasources.prometheus),
-          ],
+          vars.multiInstance,
           uid + '-overview',
           tags,
           links { ibmDb2Overview+:: {} },

--- a/mixin/dashboards_out/ibm-db2-overview.json
+++ b/mixin/dashboards_out/ibm-db2-overview.json
@@ -789,7 +789,7 @@
                   "uid": "${prometheus_datasource}"
                },
                "includeAll": true,
-               "label": "Database_name",
+               "label": "Database",
                "multi": true,
                "name": "database_name",
                "query": "label_values(ibm_db2_application_active{job=~\"$job\",cluster=~\"$cluster\",instance=~\"$instance\"}, database_name)",
@@ -804,17 +804,6 @@
                "query": "loki",
                "regex": "(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+",
                "type": "datasource"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${prometheus_datasource}"
-               },
-               "multi": true,
-               "name": "database_name",
-               "query": "label_values(ibm_db2_application_active{job=~\"$job\",cluster=~\"$cluster\",instance=~\"$instance\",database_name=~\"$database_name\"}, database_name)",
-               "refresh": 2,
-               "type": "query"
             }
          ]
       },

--- a/mixin/mixin.libsonnet
+++ b/mixin/mixin.libsonnet
@@ -15,6 +15,9 @@ local label_patch = {
   cluster+: {
     allValue: '.*',
   },
+  database_name+: {
+    label: 'Database',
+  },
 };
 
 {


### PR DESCRIPTION
This was because we were specifying in both the instanceLabels of the config and appending to the overview dashboard. Also changed the label to match what was previously just labeled as 'Database'